### PR TITLE
Reproducible error in RbVmomi::VIM::finalizer

### DIFF
--- a/lib/rbvmomi/vim.rb
+++ b/lib/rbvmomi/vim.rb
@@ -41,7 +41,9 @@ class VIM < Connection
   end
 
   def close
-    VIM::SessionManager(self, 'SessionManager').Logout
+    if VIM::SessionManager(self, 'SessionManager').currentSession
+      VIM::SessionManager(self, 'SessionManager').Logout
+    end
     super
   end
 

--- a/lib/rbvmomi/vim.rb
+++ b/lib/rbvmomi/vim.rb
@@ -41,7 +41,7 @@ class VIM < Connection
   end
 
   def close
-    VIM::SessionManager(self, 'SessionManager').Logout
+    VIM::SessionManager(self, 'SessionManager').Logout rescue RbVmomi::Fault
     super
   end
 

--- a/lib/rbvmomi/vim.rb
+++ b/lib/rbvmomi/vim.rb
@@ -41,9 +41,7 @@ class VIM < Connection
   end
 
   def close
-    if VIM::SessionManager(self, 'SessionManager').currentSession
-      VIM::SessionManager(self, 'SessionManager').Logout
-    end
+    VIM::SessionManager(self, 'SessionManager').Logout
     super
   end
 


### PR DESCRIPTION
I've been getting NotAuthenticated errors autorunning specs with guard as it's one of the rare scenarios where GC can clean up RbVmomi while stdout/stderr are still synced.

If you add a begin block with a debug point in the rescue block to the finalizer, the following script should reproduce the problem:

``` ruby
require 'rbvmomi'
RbVmomi::connect(
  #<args>
).close
sleep 3
puts 'connected and closed'
```

An error should get caught when the script is cleaning up.
