### PR TITLE
ManagedEntity#path only works on a single managed entity. Adding a new Pr

### DIFF
--- a/lib/rbvmomi/vim/ManagedEntity.rb
+++ b/lib/rbvmomi/vim/ManagedEntity.rb
@@ -33,7 +33,7 @@ class RbVmomi::VIM::ManagedEntity
       }]
     )
 
-    propCollector = objs.first.propertyCollector
+    propCollector = objs.first._connection.propertyCollector
     result = propCollector.RetrieveProperties(:specSet => [filterSpec])
 
     Hash[objs.map do |obj|

--- a/lib/rbvmomi/vim/ManagedEntity.rb
+++ b/lib/rbvmomi/vim/ManagedEntity.rb
@@ -8,20 +8,18 @@ class RbVmomi::VIM::ManagedEntity
   # Retrieve the ancestors of a list of entries.
   # @return [Hash] Object-indexed hash of ancestors of entities, starting with the root.
   def self.paths objs
-    i = 0
     filterSpec = RbVmomi::VIM.PropertyFilterSpec(
       :objectSet => objs.map do |obj|
-        i += 1
         RbVmomi::VIM.ObjectSpec(
           :obj => obj,
           :selectSet => [
             RbVmomi::VIM.TraversalSpec(
-              :name => "tsME-#{i}",
+              :name => "tsME",
               :type => 'ManagedEntity',
               :path => 'parent',
               :skip => false,
               :selectSet => [
-                RbVmomi::VIM.SelectionSpec(:name => "tsME-#{i}")
+                RbVmomi::VIM.SelectionSpec(:name => "tsME")
               ]
             )
           ]

--- a/lib/rbvmomi/vim/PropertyCollector.rb
+++ b/lib/rbvmomi/vim/PropertyCollector.rb
@@ -24,44 +24,6 @@ class RbVmomi::VIM::PropertyCollector
   end
   
   def pathsOfMany objs
-    i = 0
-    filterSpec = RbVmomi::VIM.PropertyFilterSpec(
-      :objectSet => objs.map do |obj|
-        i += 1
-        RbVmomi::VIM.ObjectSpec(
-          :obj => obj,
-          :selectSet => [
-            RbVmomi::VIM.TraversalSpec(
-              :name => "tsME-#{i}",
-              :type => 'ManagedEntity',
-              :path => 'parent',
-              :skip => false,
-              :selectSet => [
-                RbVmomi::VIM.SelectionSpec(:name => "tsME-#{i}")
-              ]
-            )
-          ]
-        )
-      end,
-      :propSet => [{
-        :pathSet => %w(name parent),
-        :type => 'ManagedEntity'
-      }]
-    )
-
-    result = self.RetrieveProperties(:specSet => [filterSpec])
-
-    Hash[objs.map do |obj|
-      tree = {}
-      result.each { |x| tree[x.obj] = [x['parent'], x['name']] }
-      a = []
-      cur = obj
-      while cur
-        parent, name = *tree[cur]
-        a << [cur, name]
-        cur = parent
-      end
-      [obj, a.reverse]
-    end]
+    RbVmomi::VIM::ManagedEntity.paths objs
   end
 end

--- a/lib/rbvmomi/vim/PropertyCollector.rb
+++ b/lib/rbvmomi/vim/PropertyCollector.rb
@@ -22,8 +22,4 @@ class RbVmomi::VIM::PropertyCollector
       [x.obj, x.to_hash]
     end]
   end
-  
-  def pathsOfMany objs
-    RbVmomi::VIM::ManagedEntity.paths objs
-  end
 end

--- a/lib/rbvmomi/vim/PropertyCollector.rb
+++ b/lib/rbvmomi/vim/PropertyCollector.rb
@@ -22,4 +22,46 @@ class RbVmomi::VIM::PropertyCollector
       [x.obj, x.to_hash]
     end]
   end
+  
+  def pathsOfMany objs
+    i = 0
+    filterSpec = RbVmomi::VIM.PropertyFilterSpec(
+      :objectSet => objs.map do |obj|
+        i += 1
+        RbVmomi::VIM.ObjectSpec(
+          :obj => obj,
+          :selectSet => [
+            RbVmomi::VIM.TraversalSpec(
+              :name => "tsME-#{i}",
+              :type => 'ManagedEntity',
+              :path => 'parent',
+              :skip => false,
+              :selectSet => [
+                RbVmomi::VIM.SelectionSpec(:name => "tsME-#{i}")
+              ]
+            )
+          ]
+        )
+      end,
+      :propSet => [{
+        :pathSet => %w(name parent),
+        :type => 'ManagedEntity'
+      }]
+    )
+
+    result = self.RetrieveProperties(:specSet => [filterSpec])
+
+    Hash[objs.map do |obj|
+      tree = {}
+      result.each { |x| tree[x.obj] = [x['parent'], x['name']] }
+      a = []
+      cur = obj
+      while cur
+        parent, name = *tree[cur]
+        a << [cur, name]
+        cur = parent
+      end
+      [obj, a.reverse]
+    end]
+  end
 end


### PR DESCRIPTION
ManagedEntity#path only works on a single managed entity. Adding a new PropertyCollector#pathsOfMany method that batches getting the path of many ManagedEntitys.
