### PR TITLE
add the ability use an autovivifying hash in the inventory method

### DIFF
--- a/lib/rbvmomi/vim/Folder.rb
+++ b/lib/rbvmomi/vim/Folder.rb
@@ -169,6 +169,11 @@ class RbVmomi::VIM::Folder
     rec = lambda { |parent| Hash[(children[parent]||[]).map { |x| [x, rec[x.obj]] }] }
     rec[self]
   end
+  
+  # Utility function that allows for an autovivifying hash
+  def chain_hash
+    Hash.new {|x,i| x[i] = chain_hash}
+  end
 
   # Efficiently retrieve properties from descendants of this folder.
   #
@@ -185,7 +190,7 @@ class RbVmomi::VIM::Folder
   # @deprecated
   def inventory propSpecs={}
     inv = inventory_flat propSpecs
-    tree = { self => {} }
+    tree = chain_hash
     inv.each do |obj,x|
       next if obj == self
       h = Hash[x.propSet.map { |y| [y.name, y.val] }]


### PR DESCRIPTION
This allows for the use of the inventory method in this fashion

VIM = RbVmomi::VIM
vim = VIM.connect opts
dc=vim.serviceInstance.find_datacenter('MyDC')
inventory = dc.vmFolder.inventory( 'VirtualMachine' => :all )

otherwise this method returns an error about assigning an array to a NilClass.
