### PR TITLE
Allows passing a cookie option to VIM.connect

### DIFF
--- a/lib/rbvmomi/trivial_soap.rb
+++ b/lib/rbvmomi/trivial_soap.rb
@@ -14,7 +14,7 @@ class RbVmomi::TrivialSoap
     @opts = opts
     return unless @opts[:host] # for testcases
     @debug = @opts[:debug]
-    @cookie = nil
+    @cookie = @opts[:cookie]
     @lock = Mutex.new
     @http = nil
     restart_http


### PR DESCRIPTION
Allows you to reconnect without having to store user/pass credentials.  Very useful when using the API from a custom web frontend.

Fixes issue #17.
