### PR TITLE
Add methods to easily add and remove disks from VM

### DIFF
--- a/lib/rbvmomi/vim/Datastore.rb
+++ b/lib/rbvmomi/vim/Datastore.rb
@@ -50,8 +50,9 @@ class RbVmomi::VIM::Datastore
     fail "upload failed" unless $?.success?
   end
 
-  # Returns the file's full path in the datastore (excluding datastore name)
+  # Find the file's full path in the datastore (excluding datastore name)
   # @params file [String]
+  # @return [String] of the file's path
   def find_file_path file
     @results = files_in_sub(nil)
     @results.each do |result|
@@ -63,6 +64,10 @@ class RbVmomi::VIM::Datastore
     fail "Could not find file"
   end
 
+  # Return's the fileInfo for a specified file
+  # @params file [String] the file for which fileInfo is to be returned
+  # @params path (optional) the path for the file
+  # @return [FileInfo] object for the file
   def get_file_info(options={})
     @file = options[:file]
     @path = options[:path]
@@ -82,7 +87,7 @@ class RbVmomi::VIM::Datastore
     fail "Could not find file"
   end
 
-  # Returns all files in a datastore path and sub-directories
+  # Find all files in a datastore path and sub-directories
   # @param path (optional) [String] Path to search for file under
   # @return [Array] of files found
   def files_in_sub path
@@ -102,7 +107,7 @@ class RbVmomi::VIM::Datastore
     @return
   end
 
-  # Returns all files in a datastore path
+  # Find all files in a datastore path
   # @param path (optional) [String] Path to search for file under
   # @return [Array] of files found
   def files_in_dir path

--- a/lib/rbvmomi/vim/VirtualMachine.rb
+++ b/lib/rbvmomi/vim/VirtualMachine.rb
@@ -10,4 +10,51 @@ class RbVmomi::VIM::VirtualMachine
   def disks
     self.config.hardware.device.grep(RbVmomi::VIM::VirtualDisk)
   end
+
+  # Retrieve all virtual controllers
+  # @return [Array] Array of virtual controllers
+  def controllers
+    self.config.hardware.device.grep(RbVmomi::VIM::VirtualController)
+  end
+
+  # Add specified VMDK as a disk to VM
+  def add_vmdk(options={})
+    defaults = {
+      :controller => "SCSI controller 0",
+    }
+    options = defaults.merge(options)
+      fail "Please provide a datastore" unless options[:datastore].is_a? RbVmomi::VIM::Datastore
+
+    @ds = options[:datastore]
+    @vmdk = options[:vmdk]
+
+    @file_path = @ds.find_file_path(@vmdk)
+    @full_file_path = "#{@file_path}#{@vmdk}"
+
+    @disk_backing_info = RbVmomi::VIM::VirtualDiskFlatVer2BackingInfo.new(  :datastore => @ds, 
+                                                                            :fileName => @full_file_path, 
+                                                                            :diskMode => "persistent")
+
+    @vm_controllers = self.controllers
+
+    @vm_controller = nil
+    @vm_controllers.each { |c| @vm_controller = c if c.deviceInfo.label == options[:controller] }
+    fail "Could not find Virtual Controller #{options[:controller]}" if @vm_controller.nil?
+
+    # Because the unit number starts at 0, count will return the next value we can use
+    @unit_number = @vm_controller.device.count
+
+    @capacityKb  = @ds.get_file_info(@vmdk).capacityKb
+    @disk = RbVmomi::VIM::VirtualDisk.new(:controllerKey => @vm_controller.key, 
+                                          :unitNumber => @unit_number,
+                                          :key => -1,
+                                          :backing => @disk_backing_info,
+                      :capacityInKB => @capacityKb)
+    @dev_spec = RbVmomi::VIM::VirtualDeviceConfigSpec.new(  :operation => RbVmomi::VIM::VirtualDeviceConfigSpecOperation.new('add'),
+                                                            :device => @disk)
+    @vm_spec = RbVmomi::VIM::VirtualMachineConfigSpec.new( :deviceChange => [*@dev_spec] )
+
+    puts "Reconfiguring #{self.name} to add VMDK: #{@full_file_path}"
+    ReconfigVM_Task( :spec => @vm_spec ).wait_for_completion
+  end
 end

--- a/lib/rbvmomi/vim/VirtualMachine.rb
+++ b/lib/rbvmomi/vim/VirtualMachine.rb
@@ -23,6 +23,7 @@ class RbVmomi::VIM::VirtualMachine
   # @param vmdk_path (optional) [String] the path to the vmdk file
   # @param controller (optional) [String] the controller to add the VirtualDisk to. 
   #   Defaults to "SCSI controller 0"
+  # @return nil on success
   def add_vmdk(options={})
     defaults = {
       :controller => "SCSI controller 0",
@@ -75,6 +76,7 @@ class RbVmomi::VIM::VirtualMachine
   # @param vmdk [String] the name of the disk file we want to remove
   # @param vmdk_path (optional) [String] the path to the disk file
   # @param destroy (optional) [Boolean] whether or not to delete the underlying disk file
+  # @return nil on success
   def remove_disk(options={})
     defaults = {
       :destroy => false,
@@ -114,7 +116,9 @@ class RbVmomi::VIM::VirtualMachine
     ReconfigVM_Task(:spec => @vm_spec).wait_for_completion
   end
 
-  # Expects the full path to the file
+  # Find a disk attached to this VM
+  # @param file [String] the name of the file for the VirtualDisk
+  # @param datastore [RbVmomi::VIM::Datastore] the datastore to look for the disk in
   def find_disk(options={})
     @file = options[:file]
     @datastore = options[:datastore]

--- a/lib/rbvmomi/vim/VirtualMachine.rb
+++ b/lib/rbvmomi/vim/VirtualMachine.rb
@@ -125,9 +125,8 @@ class RbVmomi::VIM::VirtualMachine
     @datastore = options[:datastore]
 
     @disk = nil
-    @devices = self.config.hardware.device
+    @devices = self.disks
     @devices.each do |device|
-      next unless device.is_a? RbVmomi::VIM::VirtualDisk
       next unless device.backing.is_a? RbVmomi::VIM::VirtualDeviceFileBackingInfo
       @device_datastore,@device_file = device.backing.fileName.gsub(/(\[|\])/, '').split(' ')
       if @device_file == @file and @device_datastore == @datastore.info.name

--- a/lib/rbvmomi/vim/VirtualMachine.rb
+++ b/lib/rbvmomi/vim/VirtualMachine.rb
@@ -18,18 +18,30 @@ class RbVmomi::VIM::VirtualMachine
   end
 
   # Add specified VMDK as a disk to VM
+  # @param datastore [RbVmomi::VIM::Datastore] the datastore hosting the VMDK to be added
+  # @param vmdk [String] the name of the vmdk we want to add
+  # @param vmdk_path (optional) [String] the path to the vmdk file
+  # @param controller (optional) [String] the controller to add the VirtualDisk to. 
+  #   Defaults to "SCSI controller 0"
   def add_vmdk(options={})
     defaults = {
       :controller => "SCSI controller 0",
     }
     options = defaults.merge(options)
-      fail "Please provide a datastore" unless options[:datastore].is_a? RbVmomi::VIM::Datastore
+    fail "Please provide a datastore" unless options[:datastore].is_a? RbVmomi::VIM::Datastore
 
     @ds = options[:datastore]
-    @vmdk = options[:vmdk]
+    @vmdk = options[:file]
+    @vmdk_path = options[:vmdk_path]
+    @controller = options[:controller]
 
-    @file_path = @ds.find_file_path(@vmdk)
-    @full_file_path = "#{@file_path}#{@vmdk}"
+    if @vmdk_path.nil?
+      @file_path = @ds.find_file_path(@vmdk)
+    else 
+      @file_path = @vmdk_path
+    end
+
+    @full_file_path = "[#{@ds.info.name}] #{@file_path}#{@vmdk}"
 
     @disk_backing_info = RbVmomi::VIM::VirtualDiskFlatVer2BackingInfo.new(  :datastore => @ds, 
                                                                             :fileName => @full_file_path, 
@@ -38,23 +50,86 @@ class RbVmomi::VIM::VirtualMachine
     @vm_controllers = self.controllers
 
     @vm_controller = nil
-    @vm_controllers.each { |c| @vm_controller = c if c.deviceInfo.label == options[:controller] }
-    fail "Could not find Virtual Controller #{options[:controller]}" if @vm_controller.nil?
+    @vm_controllers.each { |c| @vm_controller = c if c.deviceInfo.label == @controller }
+    fail "Could not find Virtual Controller #{@controller}" if @vm_controller.nil?
 
     # Because the unit number starts at 0, count will return the next value we can use
     @unit_number = @vm_controller.device.count
 
-    @capacityKb  = @ds.get_file_info(@vmdk).capacityKb
+    @capacityKb  = @ds.get_file_info(:file => @vmdk, :path => @file_path).capacityKb
     @disk = RbVmomi::VIM::VirtualDisk.new(:controllerKey => @vm_controller.key, 
                                           :unitNumber => @unit_number,
                                           :key => -1,
                                           :backing => @disk_backing_info,
-                      :capacityInKB => @capacityKb)
+                                          :capacityInKB => @capacityKb)
     @dev_spec = RbVmomi::VIM::VirtualDeviceConfigSpec.new(  :operation => RbVmomi::VIM::VirtualDeviceConfigSpecOperation.new('add'),
                                                             :device => @disk)
     @vm_spec = RbVmomi::VIM::VirtualMachineConfigSpec.new( :deviceChange => [*@dev_spec] )
 
     puts "Reconfiguring #{self.name} to add VMDK: #{@full_file_path}"
     ReconfigVM_Task( :spec => @vm_spec ).wait_for_completion
+  end
+
+  # Remove specified disk from the VM
+  # @param datastore [RbVmomi::VIM::Datastore] the datastore hosting the file to be removed
+  # @param vmdk [String] the name of the disk file we want to remove
+  # @param vmdk_path (optional) [String] the path to the disk file
+  # @param destroy (optional) [Boolean] whether or not to delete the underlying disk file
+  def remove_disk(options={})
+    defaults = {
+      :destroy => false,
+    }
+    options = defaults.merge(options)
+    @ds = options[:datastore]
+    @file = options[:file]
+    @path = options[:path]
+    @destroy = options[:destroy]
+
+    if @path.nil?
+      @path = @ds.find_file_path(@file)
+    end
+
+    fail "Please provide a datastore" unless @ds.is_a? RbVmomi::VIM::Datastore
+
+    @disk = self.find_disk(:datastore => @ds, :file => "#{@path}#{@file}")
+
+    fail "Couldn't find disk attached to #{self.name} for file #{@file}" if @disk.nil?
+
+    @config_remove_operation = RbVmomi::VIM::VirtualDeviceConfigSpecOperation.new('remove');
+    if @destroy
+      @config_destroy_operation = RbVmomi::VIM::VirtualDeviceConfigSpecFileOperation.new('destroy');
+      @device_spec = RbVmomi::VIM::VirtualDeviceConfigSpec.new( :operation => @config_remove_operation,
+                                                                :device => @disk,
+                                                                :fileOperations => @config_destroy_operation)
+
+      puts "Reconfiguring #{self.name} to destroy disk #{@path}#{@file}"
+    else
+      @device_spec = RbVmomi::VIM::VirtualDeviceConfigSpec.new( :operation => @config_remove_operation,
+                                                                :device => @disk)
+      puts "Reconfiguring #{self.name} to remove disk #{@path}#{@file}"
+    end
+
+    @vm_spec = RbVmomi::VIM::VirtualMachineConfigSpec.new(:deviceChange => [*@device_spec])
+
+    ReconfigVM_Task(:spec => @vm_spec).wait_for_completion
+  end
+
+  # Expects the full path to the file
+  def find_disk(options={})
+    @file = options[:file]
+    @datastore = options[:datastore]
+
+    @disk = nil
+    @devices = self.config.hardware.device
+    @devices.each do |device|
+      next unless device.is_a? RbVmomi::VIM::VirtualDisk
+      next unless device.backing.is_a? RbVmomi::VIM::VirtualDeviceFileBackingInfo
+      @device_datastore,@device_file = device.backing.fileName.gsub(/(\[|\])/, '').split(' ')
+      if @device_file == @file and @device_datastore == @datastore.info.name
+        return device
+      end
+    end
+
+    fail "Didn't find disk for file #{@file}"
   end
 end


### PR DESCRIPTION
Create several new methods, specifically add_disk and remove_disk to allow disks to be easily added and removed to/from a VirtualMachine.

We're also adding a few other methods to Datastore class to find certain files and information about those files. Also methods to the VirtualMachine class to find all controllers and a specific disks 
