### PR TITLE
Changed type of Integer anyType parameters to int from long. 

### DIFF
--- a/lib/rbvmomi/connection.rb
+++ b/lib/rbvmomi/connection.rb
@@ -167,7 +167,7 @@ class Connection < TrivialSoap
         xml.tag! name, o.to_s, attrs
       end
     when Integer
-      attrs['xsi:type'] = 'xsd:long' if expected == BasicTypes::AnyType
+      attrs['xsi:type'] = 'xsd:int' if expected == BasicTypes::AnyType
       xml.tag! name, o.to_s, attrs
     when Float
       attrs['xsi:type'] = 'xsd:double' if expected == BasicTypes::AnyType


### PR DESCRIPTION
Not sure if this is always appropriate to do or whether some sort of hint could be provided somehow to allow it to be tweaked. Seems that the long is being rejected by some validation of the anyType in vSphere.

Always setting to long or int seems like it will potentially break things that are expecting other types. I thought about looking at the size of the integer and selecting the appropriate xml type, but again this would potentially break parts of the API expecting an int (I have checked this with my use case which is to delete a DRS rule and short or long types break validation)

Example use case:

cluster = search.dc.find_compute_resource 'cluster_name'

rule_spec = RbVmomi::VIM.ClusterRuleSpec(
    operation: RbVmomi::VIM.ArrayUpdateOperation('remove'), 
    removeKey: 2
)

spec = RbVmomi::VIM.ClusterConfigSpecEx(:rulesSpec => [rule_spec])

cluster.ReconfigureComputeResource_Task(
    spec: spec,
    modify: true
).wait_for_completion

This fails currently as the api expects a int xml type for the removeKey where the current implementation sends it as a long. I have tested sending as a short and this also fails.

I think that being able to send in a hint somehow would be the best idea, but looks like a big refactor in the "Here be dragons" code.
