### PR TITLE
Simplify finding snapshots for a VM

### DIFF
--- a/lib/rbvmomi/vim/VirtualMachine.rb
+++ b/lib/rbvmomi/vim/VirtualMachine.rb
@@ -10,4 +10,38 @@ class RbVmomi::VIM::VirtualMachine
   def disks
     self.config.hardware.device.grep(RbVmomi::VIM::VirtualDisk)
   end
+
+  # Retrieve all snapshots for this Virtual Machine
+  # @return [Array] Array of VirtualMachineSnapshotTrees
+  def snapshot_list(node=nil)
+    unless node
+      if self.snapshot
+        node = self.snapshot.rootSnapshotList
+      else
+        return []
+      end
+    end
+
+    list = []
+
+    node.each do |child|
+      list << child
+
+      unless child.childSnapshotList.empty?
+        list << snapshot_list(child.childSnapshotList)
+      end
+    end
+
+    list.flatten
+  end
+
+  # Retrieve a snapshot object by name
+  # @return VirtualMachineSnapshot for named snapshot
+  def find_snapshot(name)
+    snapshot_list.each do |snapshot|
+      return snapshot.snapshot if snapshot.name == name
+    end
+    return nil
+  end
+
 end


### PR DESCRIPTION
Added 'snapshot_list' and 'find_snapshot(name)' methods to the
VirtualMachine class to simplify the process of finding snapshots
for a given VM.
